### PR TITLE
Handle null values without throwing NullPointerException

### DIFF
--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/Experiment.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/Experiment.java
@@ -7,6 +7,7 @@ import com.github.rawls238.scientist4j.exceptions.MismatchException;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -59,7 +60,7 @@ public class Experiment<T> {
     }
 
     public Experiment(String name, Map<String, Object> context, boolean raiseOnMismatch, MetricRegistry metricRegistry) {
-        this(name, context, raiseOnMismatch, metricRegistry, Object::equals);
+        this(name, context, raiseOnMismatch, metricRegistry, Objects::equals);
     }
 
     public Experiment(String name, Map<String, Object> context, boolean raiseOnMismatch, MetricRegistry metricRegistry, BiFunction<T, T, Boolean> comparator) {

--- a/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/ExperimentTest.java
+++ b/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/ExperimentTest.java
@@ -62,6 +62,14 @@ public class ExperimentTest {
     }
 
     @Test
+    public void itHandlesNullValues() throws Exception {
+        Integer val = new Experiment<Integer>("test", true)
+                .run(() -> null, () -> null);
+
+        assertThat(val).isNull();
+    }
+
+    @Test
     public void nonAsyncRunsLongTime() throws Exception {
         Experiment<Integer> exp = new Experiment<>("test", true);
         Date date1 = new Date();


### PR DESCRIPTION
By using Objects::equals instead of Object::equals NullpointerExceptions are avoided