### PR TITLE
added toString() to comparison failure

### DIFF
--- a/Scientist4JCore/pom.xml
+++ b/Scientist4JCore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.rawls238</groupId>
         <artifactId>Scientist4J</artifactId>
-        <version>0.4</version>
+        <version>0.5</version>
     </parent>
     <artifactId>Scientist4JCore</artifactId>
 

--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/Experiment.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/Experiment.java
@@ -213,7 +213,7 @@ public class Experiment<T> {
                 .append(exceptionName).append(" ").append(stackTrace).toString();
         } else {
             msg = new StringBuilder().append(candidateVal.getName()).append(" does not match control value (")
-                .append(controlVal.getValue()).append(" != ").append(candidateVal.getValue()).append(")").toString();
+                .append(controlVal.getValue().toString()).append(" != ").append(candidateVal.getValue().toString()).append(")").toString();
         }
         throw new MismatchException(msg);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.rawls238</groupId>
     <artifactId>Scientist4J</artifactId>
-    <version>0.4</version>
+    <version>0.5</version>
     <packaging>pom</packaging>
 
     <name>Scientist4J</name>


### PR DESCRIPTION
I'm trying to log comparison failures and currently for created POJOs the exception doesn't give any information about which objects go wrong. Adding the toString() someone can override it for their POJOs and create a clear message which values go wrong.