### PR TITLE
Do not block on candidate function results in async implementation

### DIFF
--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/Experiment.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/Experiment.java
@@ -120,20 +120,21 @@ public class Experiment<T> {
         return controlObservation.getValue();
     }
 
-    public T runAsync(Supplier<T> control, Supplier<T> candidate) throws Exception {
-        Future<Optional<Observation<T>>> observationFutureCandidate = null;
+    public T runAsync(Supplier<T> control, Supplier<T> candidate) {
+        Future<Optional<Observation<T>>> observationFutureCandidate;
         Future<Observation<T>> observationFutureControl;
 
-        if (Math.random() < 0.5) {
-            observationFutureControl = executor.submit(() -> executeResult("control", controlTimer, control, true));
-            if (runIf() && enabled()) {
+        if (runIf() && enabled()) {
+            if (Math.random() < 0.5) {
+                observationFutureControl = executor.submit(() -> executeResult("control", controlTimer, control, true));
                 observationFutureCandidate = executor.submit(() -> Optional.of(executeResult("candidate", candidateTimer, candidate, false)));
+            } else {
+                observationFutureCandidate = executor.submit(() -> Optional.of(executeResult("candidate", candidateTimer, candidate, false)));
+                observationFutureControl = executor.submit(() -> executeResult("control", controlTimer, control, true));
             }
         } else {
-            if (runIf() && enabled()) {
-                observationFutureCandidate = executor.submit(() -> Optional.of(executeResult("candidate", candidateTimer, candidate, false)));
-            }
             observationFutureControl = executor.submit(() -> executeResult("control", controlTimer, control, true));
+            observationFutureCandidate = null;
         }
 
         Observation<T> controlObservation;
@@ -142,15 +143,25 @@ public class Experiment<T> {
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
         }
-        Optional<Observation<T>> candidateObservation = Optional.empty();
-        if (observationFutureCandidate != null) {
-            candidateObservation = observationFutureCandidate.get();
-        }
 
-        countExceptions(candidateObservation, candidateExceptionCount);
-        Result<T> result = new Result<>(this, controlObservation, candidateObservation, context);
-        publish(result);
+        executor.submit(() -> publishAsync(controlObservation, observationFutureCandidate));
+
         return controlObservation.getValue();
+    }
+
+    private void publishAsync(Observation<T> controlObservation, Future<Optional<Observation<T>>> observationFutureCandidate) {
+        try {
+            Optional<Observation<T>> candidateObservation = Optional.empty();
+            if (observationFutureCandidate != null) {
+                candidateObservation = observationFutureCandidate.get();
+            }
+
+            countExceptions(candidateObservation, candidateExceptionCount);
+            Result<T> result = new Result<>(this, controlObservation, candidateObservation, context);
+            publish(result);
+        } catch (Exception ignored) {
+
+        }
     }
 
     private void countExceptions(Optional<Observation<T>> observation, Counter exceptions) {

--- a/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/ExperimentAsyncTest.java
+++ b/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/ExperimentAsyncTest.java
@@ -1,6 +1,5 @@
 package com.github.rawls238.scientist4j;
 
-import com.github.rawls238.scientist4j.exceptions.MismatchException;
 import org.junit.Test;
 
 import java.util.Date;
@@ -22,70 +21,48 @@ public class ExperimentAsyncTest {
     return 3;
   }
 
-    private Integer safeFunction() {
-      return 3;
+  private Integer shortSleepFunction() {
+    try {
+      Thread.sleep(101);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
     }
+    return 3;
+  }
 
-    private Integer safeFunctionWithDifferentResult() {
-      return 4;
+  private Integer safeFunction() {
+    return 3;
+  }
+
+  @Test
+  public void itThrowsAnExceptionWhenControlFails() {
+    Experiment experiment = new Experiment("test");
+    boolean controlThrew = false;
+    try {
+      experiment.runAsync(this::exceptionThrowingFunction, this::exceptionThrowingFunction);
+    } catch (RuntimeException e) {
+      controlThrew = true;
+    } catch (Exception e) {
+
     }
-
-    @Test
-    public void itThrowsAnExceptionWhenControlFails() {
-      Experiment experiment = new Experiment("test");
-      boolean controlThrew = false;
-      try {
-        experiment.runAsync(this::exceptionThrowingFunction, this::exceptionThrowingFunction);
-      } catch (RuntimeException e) {
-        controlThrew = true;
-      } catch (Exception e) {
-
-      }
-      assertThat(controlThrew).isEqualTo(true);
-    }
+    assertThat(controlThrew).isEqualTo(true);
+  }
 
   @Test
   public void itDoesntThrowAnExceptionWhenCandidateFails() {
     Experiment<Integer> experiment = new Experiment("test");
-    boolean candidateThrew = false;
     Integer val = 0;
-    try {
-      val = experiment.runAsync(this::safeFunction, this::exceptionThrowingFunction);
-    } catch (Exception e) {
-      candidateThrew = true;
-    }
-    assertThat(candidateThrew).isEqualTo(false);
+    val = experiment.runAsync(this::safeFunction, this::exceptionThrowingFunction);
     assertThat(val).isEqualTo(3);
-  }
-
-  @Test
-  public void itThrowsOnMismatch() {
-    Experiment<Integer> experiment = new Experiment("test", true);
-    boolean candidateThrew = false;
-    try {
-      experiment.runAsync(this::safeFunction, this::safeFunctionWithDifferentResult);
-    } catch (MismatchException e) {
-      candidateThrew = true;
-    } catch (Exception e) {
-
-    }
-
-    assertThat(candidateThrew).isEqualTo(true);
   }
 
   @Test
   public void itDoesNotThrowOnMatch() {
     Experiment<Integer> exp = new Experiment("test", true);
-    boolean candidateThrew = false;
     Integer val = 0;
-    try {
-      val = exp.runAsync(this::safeFunction, this::safeFunction);
-    } catch (Exception e) {
-      candidateThrew = true;
-    }
+    val = exp.runAsync(this::safeFunction, this::safeFunction);
 
     assertThat(val).isEqualTo(3);
-    assertThat(candidateThrew).isEqualTo(false);
   }
 
   @Test
@@ -101,22 +78,26 @@ public class ExperimentAsyncTest {
   @Test
   public void asyncRunsFaster() {
     Experiment<Integer> exp = new Experiment("test", true);
-    boolean candidateThrew = false;
     Integer val = 0;
     Date date1 = new Date();
 
-    try {
-      val = exp.runAsync(this::sleepFunction, this::sleepFunction);
-    } catch (Exception e) {
-      candidateThrew = true;
-    }
+    val = exp.runAsync(this::sleepFunction, this::sleepFunction);
     Date date2 = new Date();
     long difference = date2.getTime() - date1.getTime();
 
     assertThat(difference).isLessThan(2000);
     assertThat(difference).isGreaterThanOrEqualTo(1000);
     assertThat(val).isEqualTo(3);
-    assertThat(candidateThrew).isEqualTo(false);
+  }
+
+  @Test
+  public void raiseOnMismatchRunsSlower() {
+    Experiment<Integer> experiment = new Experiment("does not raise");
+    Date date1 = new Date();
+    experiment.runAsync(this::shortSleepFunction, this::sleepFunction);
+    Date date2 = new Date();
+    long doesNotRaiseExecutionTime = date2.getTime() - date1.getTime();
+    assertThat(doesNotRaiseExecutionTime).isLessThan(200);
   }
 
 }


### PR DESCRIPTION
Another potential solution to the issue rawls238#27:

This pull swallows all exceptions thrown by the candidate function so that `runAsync` does not block on the candidate function result. 