### PR TITLE
Set Mockito as a test dependency only

### DIFF
--- a/Scientist4JCore/pom.xml
+++ b/Scientist4JCore/pom.xml
@@ -32,6 +32,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.5.7</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Title says it all really - we're using a different version of Mockito in a project which is not a test environment and that fix should be enough for us to be able to use the library.