### PR TITLE
Add MetricsProvider interface, making Dropwizard metrics optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The metrics have the form `scientist.[experiment name].*`.
 
 Users can optionally override the following functions:
 
-* `publish` (to publish results of an experiment if you don’t want to supplement the default `MetricsProvider`’s publishing mechanism)
+* `publish` (to publish results of an experiment if you want to supplement the `MetricsProvider`’s publishing mechanism)
 * `compareResults` (by default this library just uses `equals` between objects for equality, but in case you want to special case equality between objects)
 * `enabled` (to limit what % of users get exposed to the new code path - by default it's 100%)
 * `runIf` (to enforce conditional behavior on who should be exposed to the new code path)

--- a/README.md
+++ b/README.md
@@ -49,28 +49,37 @@ Behind the scenes the following occurs in both cases:
 * Publishes all this information.
 
 
-## Dropwizard
+## Metrics
 
-Out of the box this uses [Dropwizard metrics](https://dropwizard.github.io/metrics/3.1.0/) to report the following stats.
-The following metrics are reported which have the form `scientist.[experiment name].*`:
+Out of the box this uses a `NoopMetricsProvider`. This is not very useful. You’ll want to pick use of the built-in providers or implement your own `MetricsProvider`, which will report to your chosen registry:
 
-* duration of default behavior in ms
-* duration of candidate behavior in ms
+* duration of default behavior in ns
+* duration of candidate behavior in ns
 * counter of total number of users going through the codepath
 * counter of number of mismatches
 * counter of candidate exceptions
 
-You can provide your own metric registry object/bean via the constructor or by extending the Experiment class and overriding the `getMetrics` method.
+### Dropwizard
+
+`DropwizardMetricsProvider` uses [Dropwizard metrics](https://dropwizard.github.io/metrics/) to report the experiment stats.
+The metrics have the form `scientist.[experiment name].*`.
+
+
+### Micrometer
+
+`MicrometerMetricsProvider` uses [Micrometer](https://micrometer.io) to report the experiment stats.
+The metrics have the form `scientist.[experiment name].*`.
+
 
 ## Optional Configuration
 
 Users can optionally override the following functions:
 
-* publish (to publish results of an experiment if you don't want to use the default Dropwizard metrics)
-* compareResults (by default this library just uses `equals` between objects for equality, but in case you want to special case equality between objects)
-* enabled (to limit what % of users get exposed to the new code path - by default it's 100%)
-* runIf (to enforce conditional behavior on who should be exposed to the new code path)
-* isAsync (force using the async for legacy code or move to runAsync method)
+* `publish` (to publish results of an experiment if you don’t want to supplement the default `MetricsProvider`’s publishing mechanism)
+* `compareResults` (by default this library just uses `equals` between objects for equality, but in case you want to special case equality between objects)
+* `enabled` (to limit what % of users get exposed to the new code path - by default it's 100%)
+* `runIf` (to enforce conditional behavior on who should be exposed to the new code path)
+* `isAsync` (force using the async for legacy code or move to `runAsync` method)
 
 
 License: MIT

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A port of Github's refactoring tool [Scientist](https://github.com/github/scient
 
 # Installation
 
-```java
+```xml
 <dependency>
     <groupId>com.github.rawls238</groupId>
     <artifactId>Scientist4JCore</artifactId>
@@ -51,31 +51,38 @@ Behind the scenes the following occurs in both cases:
 
 ## Metrics
 
-Out of the box this uses a `NoopMetricsProvider`. This is not very useful. You’ll want to pick use of the built-in providers or implement your own `MetricsProvider`, which will report to your chosen registry:
+Scientist4J ships with support for two common metrics libraries—[Dropwizard metrics](https://dropwizard.github.io/metrics/)
+ and [Micrometer](https://micrometer.io). As each of these is optional, you’ll need to add your choice as an explicit dependency to your project:
 
-* duration of default behavior in ns
+```xml
+<dependency>
+    <groupId>io.dropwizard.metrics5</groupId>
+    <artifactId>metrics-core</artifactId>
+</dependency>
+```
+or
+```xml
+<dependency>
+    <groupId>io.micrometer</groupId>
+    <artifactId>micrometer-core</artifactId>
+</dependency>
+```
+
+The following metrics are reported, with the form `scientist.[experiment name].*`:
+
+* duration of default (control) behavior in ns
 * duration of candidate behavior in ns
 * counter of total number of users going through the codepath
 * counter of number of mismatches
 * counter of candidate exceptions
 
-### Dropwizard
-
-`DropwizardMetricsProvider` uses [Dropwizard metrics](https://dropwizard.github.io/metrics/) to report the experiment stats.
-The metrics have the form `scientist.[experiment name].*`.
-
-
-### Micrometer
-
-`MicrometerMetricsProvider` uses [Micrometer](https://micrometer.io) to report the experiment stats.
-The metrics have the form `scientist.[experiment name].*`.
-
+You may also implement your own `MetricsProvider`, to meet your specific needs.
 
 ## Optional Configuration
 
 Users can optionally override the following functions:
 
-* `publish` (to publish results of an experiment if you want to supplement the `MetricsProvider`’s publishing mechanism)
+* `publish` (to publish results of an experiment, if you want to supplement the `MetricsProvider`’s publishing mechanism)
 * `compareResults` (by default this library just uses `equals` between objects for equality, but in case you want to special case equality between objects)
 * `enabled` (to limit what % of users get exposed to the new code path - by default it's 100%)
 * `runIf` (to enforce conditional behavior on who should be exposed to the new code path)

--- a/Scientist4JCore/pom.xml
+++ b/Scientist4JCore/pom.xml
@@ -14,6 +14,13 @@
             <groupId>io.dropwizard.metrics5</groupId>
             <artifactId>metrics-core</artifactId>
             <version>5.0.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.3.5</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/Experiment.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/Experiment.java
@@ -19,7 +19,7 @@ public class Experiment<T> {
 
     private final ExecutorService executor;
     private static final String NAMESPACE_PREFIX = "scientist";
-    private static final MetricsProvider metrics = new NoopMetricsProvider();
+    private static final MetricsProvider<?> metrics = new NoopMetricsProvider();
     private final String name;
     private final boolean raiseOnMismatch;
     private Map<String, Object> context;
@@ -38,7 +38,7 @@ public class Experiment<T> {
         this(name, false, null);
     }
 
-    public Experiment(String name, MetricsProvider metricsProvider) {
+    public Experiment(String name, MetricsProvider<?> metricsProvider) {
         this(name, false, metricsProvider);
     }
 
@@ -46,7 +46,7 @@ public class Experiment<T> {
         this(name, context, false, null);
     }
 
-    public Experiment(String name, Map<String, Object> context, MetricsProvider metricsProvider) {
+    public Experiment(String name, Map<String, Object> context, MetricsProvider<?> metricsProvider) {
         this(name, context, false, metricsProvider);
     }
 
@@ -54,21 +54,21 @@ public class Experiment<T> {
         this(name, new HashMap<>(), raiseOnMismatch, null);
     }
 
-    public Experiment(String name, boolean raiseOnMismatch, MetricsProvider metricsProvider) {
+    public Experiment(String name, boolean raiseOnMismatch, MetricsProvider<?> metricsProvider) {
         this(name, new HashMap<>(), raiseOnMismatch, metricsProvider);
     }
 
-    public Experiment(String name, Map<String, Object> context, boolean raiseOnMismatch, MetricsProvider metricsProvider) {
+    public Experiment(String name, Map<String, Object> context, boolean raiseOnMismatch, MetricsProvider<?> metricsProvider) {
         this(name, context, raiseOnMismatch, metricsProvider, Objects::equals);
     }
 
     public Experiment(String name, Map<String, Object> context, boolean raiseOnMismatch,
-                      MetricsProvider metricsProvider, BiFunction<T, T, Boolean> comparator) {
+                      MetricsProvider<?> metricsProvider, BiFunction<T, T, Boolean> comparator) {
         this(name, context, raiseOnMismatch, metricsProvider, comparator, Executors.newFixedThreadPool(2));
     }
 
     public Experiment(String name, Map<String, Object> context, boolean raiseOnMismatch,
-                      MetricsProvider metricsProvider, BiFunction<T, T, Boolean> comparator,
+                      MetricsProvider<?> metricsProvider, BiFunction<T, T, Boolean> comparator,
                       ExecutorService executorService) {
         this.name = name;
         this.context = context;
@@ -86,7 +86,7 @@ public class Experiment<T> {
      * Allow override here if extending the class, use the one passed into constructor if not null
      * or resort to the default created one internally
      */
-    public MetricsProvider getMetrics(MetricsProvider metricsProvider) {
+    public MetricsProvider<?> getMetrics(MetricsProvider<?> metricsProvider) {
         return metricsProvider != null ? metricsProvider : metrics;
     }
 

--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/Experiment.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/Experiment.java
@@ -1,9 +1,8 @@
 package com.github.rawls238.scientist4j;
 
 import com.github.rawls238.scientist4j.exceptions.MismatchException;
-import io.dropwizard.metrics5.Counter;
-import io.dropwizard.metrics5.MetricRegistry;
-import io.dropwizard.metrics5.Timer;
+import com.github.rawls238.scientist4j.metrics.MetricsProvider;
+import com.github.rawls238.scientist4j.metrics.NoopMetricsProvider;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,15 +19,15 @@ public class Experiment<T> {
 
     private final ExecutorService executor;
     private static final String NAMESPACE_PREFIX = "scientist";
-    private static final MetricRegistry metrics = new MetricRegistry();
+    private static final MetricsProvider metrics = new NoopMetricsProvider();
     private final String name;
     private final boolean raiseOnMismatch;
     private Map<String, Object> context;
-    private final Timer controlTimer;
-    private final Timer candidateTimer;
-    private final Counter mismatchCount;
-    private final Counter candidateExceptionCount;
-    private final Counter totalCount;
+    private final MetricsProvider.Timer controlTimer;
+    private final MetricsProvider.Timer candidateTimer;
+    private final MetricsProvider.Counter mismatchCount;
+    private final MetricsProvider.Counter candidateExceptionCount;
+    private final MetricsProvider.Counter totalCount;
     private final BiFunction<T, T, Boolean> comparator;
 
     public Experiment() {
@@ -39,47 +38,47 @@ public class Experiment<T> {
         this(name, false, null);
     }
 
-    public Experiment(String name, MetricRegistry metricRegistry) {
-        this(name, false, metricRegistry);
+    public Experiment(String name, MetricsProvider metricsProvider) {
+        this(name, false, metricsProvider);
     }
 
     public Experiment(String name, Map<String, Object> context) {
         this(name, context, false, null);
     }
 
-    public Experiment(String name, Map<String, Object> context, MetricRegistry metricRegistry) {
-        this(name, context, false, metricRegistry);
+    public Experiment(String name, Map<String, Object> context, MetricsProvider metricsProvider) {
+        this(name, context, false, metricsProvider);
     }
 
     public Experiment(String name, boolean raiseOnMismatch) {
         this(name, new HashMap<>(), raiseOnMismatch, null);
     }
 
-    public Experiment(String name, boolean raiseOnMismatch, MetricRegistry metricRegistry) {
-        this(name, new HashMap<>(), raiseOnMismatch, metricRegistry);
+    public Experiment(String name, boolean raiseOnMismatch, MetricsProvider metricsProvider) {
+        this(name, new HashMap<>(), raiseOnMismatch, metricsProvider);
     }
 
-    public Experiment(String name, Map<String, Object> context, boolean raiseOnMismatch, MetricRegistry metricRegistry) {
-        this(name, context, raiseOnMismatch, metricRegistry, Objects::equals);
-    }
-
-    public Experiment(String name, Map<String, Object> context, boolean raiseOnMismatch,
-                      MetricRegistry metricRegistry, BiFunction<T, T, Boolean> comparator) {
-        this(name, context, raiseOnMismatch, metricRegistry, comparator, Executors.newFixedThreadPool(2));
+    public Experiment(String name, Map<String, Object> context, boolean raiseOnMismatch, MetricsProvider metricsProvider) {
+        this(name, context, raiseOnMismatch, metricsProvider, Objects::equals);
     }
 
     public Experiment(String name, Map<String, Object> context, boolean raiseOnMismatch,
-                      MetricRegistry metricRegistry, BiFunction<T, T, Boolean> comparator,
+                      MetricsProvider metricsProvider, BiFunction<T, T, Boolean> comparator) {
+        this(name, context, raiseOnMismatch, metricsProvider, comparator, Executors.newFixedThreadPool(2));
+    }
+
+    public Experiment(String name, Map<String, Object> context, boolean raiseOnMismatch,
+                      MetricsProvider metricsProvider, BiFunction<T, T, Boolean> comparator,
                       ExecutorService executorService) {
         this.name = name;
         this.context = context;
         this.raiseOnMismatch = raiseOnMismatch;
         this.comparator = comparator;
-        controlTimer = getMetrics(metricRegistry).timer(MetricRegistry.name(NAMESPACE_PREFIX, this.name, "control"));
-        candidateTimer = getMetrics(metricRegistry).timer(MetricRegistry.name(NAMESPACE_PREFIX, this.name, "candidate"));
-        mismatchCount = getMetrics(metricRegistry).counter(MetricRegistry.name(NAMESPACE_PREFIX, this.name, "mismatch"));
-        candidateExceptionCount = getMetrics(metricRegistry).counter(MetricRegistry.name(NAMESPACE_PREFIX, this.name, "candidate.exception"));
-        totalCount = getMetrics(metricRegistry).counter(MetricRegistry.name(NAMESPACE_PREFIX, this.name, "total"));
+        controlTimer = getMetrics(metricsProvider).timer(NAMESPACE_PREFIX, this.name, "control");
+        candidateTimer = getMetrics(metricsProvider).timer(NAMESPACE_PREFIX, this.name, "candidate");
+        mismatchCount = getMetrics(metricsProvider).counter(NAMESPACE_PREFIX, this.name, "mismatch");
+        candidateExceptionCount = getMetrics(metricsProvider).counter(NAMESPACE_PREFIX, this.name, "candidate.exception");
+        totalCount = getMetrics(metricsProvider).counter(NAMESPACE_PREFIX, this.name, "total");
         executor = executorService;
     }
 
@@ -87,8 +86,8 @@ public class Experiment<T> {
      * Allow override here if extending the class, use the one passed into constructor if not null
      * or resort to the default created one internally
      */
-    public MetricRegistry getMetrics(MetricRegistry metricRegistry) {
-        return metricRegistry != null ? metricRegistry : metrics;
+    public MetricsProvider getMetrics(MetricsProvider metricsProvider) {
+        return metricsProvider != null ? metricsProvider : metrics;
     }
 
     /**
@@ -182,26 +181,28 @@ public class Experiment<T> {
         return null;
     }
 
-    private void countExceptions(Optional<Observation<T>> observation, Counter exceptions) {
+    private void countExceptions(Optional<Observation<T>> observation, MetricsProvider.Counter exceptions) {
         if (observation.isPresent() && observation.get().getException().isPresent()) {
-            exceptions.inc();
+            exceptions.increment();
         }
     }
 
-    public Observation<T> executeResult(String name, Timer timer, Callable<T> control, boolean shouldThrow) throws Exception {
+    public Observation<T> executeResult(String name, MetricsProvider.Timer timer, Callable<T> control, boolean shouldThrow) throws Exception {
         Observation<T> observation = new Observation<>(name, timer);
-        observation.startTimer();
-        try {
-            observation.setValue(control.call());
-        } catch (Exception e) {
-            observation.setException(e);
-        } finally {
-            observation.endTimer();
-            if (shouldThrow && observation.getException().isPresent()) {
-                throw observation.getException().get();
+
+        observation.time(() -> {
+            try {
+                observation.setValue(control.call());
+            } catch (Exception e) {
+                observation.setException(e);
             }
-            return observation;
+        });
+
+        if (shouldThrow && observation.getException().isPresent()) {
+            throw observation.getException().get();
         }
+
+        return observation;
     }
 
     protected boolean compareResults(T controlVal, T candidateVal) {
@@ -210,9 +211,9 @@ public class Experiment<T> {
 
     public boolean compare(Observation<T> controlVal, Observation<T> candidateVal) throws MismatchException {
         boolean resultsMatch = !candidateVal.getException().isPresent() && compareResults(controlVal.getValue(), candidateVal.getValue());
-        totalCount.inc();
+        totalCount.increment();
         if (!resultsMatch) {
-            mismatchCount.inc();
+            mismatchCount.increment();
             handleComparisonMismatch(controlVal, candidateVal);
         }
         return true;

--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/ExperimentBuilder.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/ExperimentBuilder.java
@@ -1,7 +1,6 @@
 package com.github.rawls238.scientist4j;
 
 import com.github.rawls238.scientist4j.metrics.MetricsProvider;
-import com.github.rawls238.scientist4j.metrics.NoopMetricsProvider;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,7 +17,6 @@ public class ExperimentBuilder<T> {
     public ExperimentBuilder() {
         context = new HashMap<>();
         comparator = Object::equals;
-        metricsProvider = new NoopMetricsProvider();
     }
 
     public ExperimentBuilder<T> withName(final String name) {
@@ -26,7 +24,7 @@ public class ExperimentBuilder<T> {
         return this;
     }
 
-    public ExperimentBuilder<T> withProvider(final MetricsProvider<?> metricsProvider) {
+    public ExperimentBuilder<T> withMetricsProvider(final MetricsProvider<?> metricsProvider) {
         this.metricsProvider = metricsProvider;
         return this;
     }
@@ -43,6 +41,7 @@ public class ExperimentBuilder<T> {
 
     public Experiment<T> build() {
         assert name != null;
+        assert metricsProvider != null;
         return new Experiment<>(name, context, false, metricsProvider, comparator,
             executorService);
     }

--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/ExperimentBuilder.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/ExperimentBuilder.java
@@ -1,6 +1,7 @@
 package com.github.rawls238.scientist4j;
 
-import io.dropwizard.metrics5.MetricRegistry;
+import com.github.rawls238.scientist4j.metrics.MetricsProvider;
+import com.github.rawls238.scientist4j.metrics.NoopMetricsProvider;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -9,7 +10,7 @@ import java.util.function.BiFunction;
 
 public class ExperimentBuilder<T> {
     private String name;
-    private MetricRegistry registry;
+    private MetricsProvider metricsProvider;
     private BiFunction<T, T, Boolean> comparator;
     private Map<String, Object> context;
     private ExecutorService executorService;
@@ -17,7 +18,7 @@ public class ExperimentBuilder<T> {
     public ExperimentBuilder() {
         context = new HashMap<>();
         comparator = Object::equals;
-        registry = new MetricRegistry();
+        metricsProvider = new NoopMetricsProvider();
     }
 
     public ExperimentBuilder<T> withName(final String name) {
@@ -25,8 +26,8 @@ public class ExperimentBuilder<T> {
         return this;
     }
 
-    public ExperimentBuilder<T> withRegistry(final MetricRegistry registry) {
-        this.registry = registry;
+    public ExperimentBuilder<T> withProvider(final MetricsProvider metricsProvider) {
+        this.metricsProvider = metricsProvider;
         return this;
     }
 
@@ -42,7 +43,7 @@ public class ExperimentBuilder<T> {
 
     public Experiment<T> build() {
         assert name != null;
-        return new Experiment<>(name, context, false, registry, comparator,
+        return new Experiment<>(name, context, false, metricsProvider, comparator,
             executorService);
     }
 }

--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/ExperimentBuilder.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/ExperimentBuilder.java
@@ -10,7 +10,7 @@ import java.util.function.BiFunction;
 
 public class ExperimentBuilder<T> {
     private String name;
-    private MetricsProvider metricsProvider;
+    private MetricsProvider<?> metricsProvider;
     private BiFunction<T, T, Boolean> comparator;
     private Map<String, Object> context;
     private ExecutorService executorService;
@@ -26,7 +26,7 @@ public class ExperimentBuilder<T> {
         return this;
     }
 
-    public ExperimentBuilder<T> withProvider(final MetricsProvider metricsProvider) {
+    public ExperimentBuilder<T> withProvider(final MetricsProvider<?> metricsProvider) {
         this.metricsProvider = metricsProvider;
         return this;
     }

--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/Observation.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/Observation.java
@@ -1,9 +1,7 @@
 package com.github.rawls238.scientist4j;
 
-import io.dropwizard.metrics5.Timer;
+import com.github.rawls238.scientist4j.metrics.MetricsProvider.Timer;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 public class Observation<T> {
@@ -11,9 +9,7 @@ public class Observation<T> {
     private String name;
     private Optional<Exception> exception;
     private T value;
-    private Timer.Context timerContext;
     private Timer timer;
-    private long duration;
 
     public Observation(String name, Timer timer) {
       this.name = name;
@@ -41,15 +37,11 @@ public class Observation<T> {
         return exception;
     }
 
-    public void startTimer() {
-        timerContext = timer.time();
-    }
-
-    public void endTimer() {
-        duration = timerContext.stop();
-    }
-
     public long getDuration() {
-        return duration;
+        return timer.getDuration();
+    }
+
+    public void time(Runnable runnable) {
+        timer.record(runnable);
     }
 }

--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/metrics/DropwizardMetricsProvider.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/metrics/DropwizardMetricsProvider.java
@@ -1,0 +1,70 @@
+package com.github.rawls238.scientist4j.metrics;
+
+import io.dropwizard.metrics5.MetricRegistry;
+import io.dropwizard.metrics5.Timer.Context;
+
+import java.util.Arrays;
+
+public class DropwizardMetricsProvider implements MetricsProvider<MetricRegistry> {
+
+    private MetricRegistry registry;
+
+    public DropwizardMetricsProvider() {
+        this(new MetricRegistry());
+    }
+
+    public DropwizardMetricsProvider(MetricRegistry metricRegistry) {
+        this.registry = metricRegistry;
+    }
+
+    @Override
+    public Timer timer(String... nameComponents) {
+        final io.dropwizard.metrics5.Timer timer = registry.timer(MetricRegistry.name(nameComponents[0], Arrays.copyOfRange(nameComponents, 1, nameComponents.length)));
+
+        return new Timer() {
+
+            long duration;
+
+            @Override
+            public void record(Runnable runnable) {
+
+                final Context context = timer.time();
+
+                try {
+                    runnable.run();
+                } finally {
+                    duration = context.stop();
+                }
+            }
+
+            @Override
+            public long getDuration() {
+                return duration;
+            }
+        };
+    }
+
+    @Override
+    public Counter counter(String... nameComponents) {
+
+        final io.dropwizard.metrics5.Counter counter = registry.counter(MetricRegistry.name(nameComponents[0], Arrays.copyOfRange(nameComponents, 1, nameComponents.length)));
+
+        return new Counter() {
+
+            @Override
+            public void increment() {
+                counter.inc();
+            }
+        };
+    }
+
+    @Override
+    public MetricRegistry getRegistry() {
+        return this.registry;
+    }
+
+    @Override
+    public void setRegistry(MetricRegistry registry) {
+        this.registry = registry;
+    }
+}

--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/metrics/MetricsProvider.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/metrics/MetricsProvider.java
@@ -1,0 +1,29 @@
+package com.github.rawls238.scientist4j.metrics;
+
+public interface MetricsProvider<T> {
+
+    Timer timer(String... nameComponents);
+
+    Counter counter(String... nameComponents);
+
+    interface Timer {
+
+        void record(Runnable runnable);
+
+        /**
+         * The duration recorded by this timer
+         *
+         * @return timer duration in nanoseconds
+         */
+        long getDuration();
+    }
+
+    interface Counter {
+
+        void increment();
+    }
+
+    T getRegistry();
+
+    void setRegistry(T registry);
+}

--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/metrics/MicrometerMetricsProvider.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/metrics/MicrometerMetricsProvider.java
@@ -1,0 +1,60 @@
+package com.github.rawls238.scientist4j.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.util.concurrent.TimeUnit;
+
+public class MicrometerMetricsProvider implements MetricsProvider<MeterRegistry> {
+
+    private MeterRegistry registry;
+
+    public MicrometerMetricsProvider() {
+        this(new SimpleMeterRegistry());
+    }
+
+    public MicrometerMetricsProvider(MeterRegistry meterRegistry) {
+        this.registry = meterRegistry;
+    }
+
+    @Override
+    public Timer timer(String... nameComponents) {
+
+        final io.micrometer.core.instrument.Timer timer = io.micrometer.core.instrument.Timer.builder(String.join(".", nameComponents)).register(this.registry);
+
+        return new Timer() {
+            @Override
+            public void record(Runnable runnable) {
+                timer.record(runnable);
+            }
+
+            @Override
+            public long getDuration() {
+                return (long)timer.totalTime(TimeUnit.NANOSECONDS);
+            }
+        };
+    }
+
+    @Override
+    public Counter counter(String... nameComponents) {
+
+        final io.micrometer.core.instrument.Counter counter = io.micrometer.core.instrument.Counter.builder(String.join(".", nameComponents)).register(this.registry);
+
+        return new Counter() {
+            @Override
+            public void increment() {
+                counter.increment();
+            }
+        };
+    }
+
+    @Override
+    public MeterRegistry getRegistry() {
+        return registry;
+    }
+
+    @Override
+    public void setRegistry(MeterRegistry registry) {
+        this.registry = registry;
+    }
+}

--- a/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/metrics/NoopMetricsProvider.java
+++ b/Scientist4JCore/src/main/java/com/github/rawls238/scientist4j/metrics/NoopMetricsProvider.java
@@ -1,0 +1,46 @@
+package com.github.rawls238.scientist4j.metrics;
+
+/**
+ * A default {@link MetricsProvider}, with a minimal in-memory implementation, suitable for test environments.
+ */
+public class NoopMetricsProvider implements MetricsProvider<Object> {
+
+    @Override
+    public Timer timer(String... nameComponents) {
+
+        return new Timer() {
+
+            long duration;
+
+            @Override
+            public void record(Runnable runnable) {
+                long now = System.nanoTime();
+                runnable.run();
+
+                duration = System.nanoTime() - now;
+            }
+
+            @Override
+            public long getDuration() {
+                return duration;
+            }
+        };
+    }
+
+    @Override
+    public Counter counter(String... nameComponents) {
+        return () -> {
+
+        };
+    }
+
+    @Override
+    public Object getRegistry() {
+        return new Object();
+    }
+
+    @Override
+    public void setRegistry(Object registry) {
+
+    }
+}

--- a/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/ExperimentAsyncTest.java
+++ b/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/ExperimentAsyncTest.java
@@ -1,6 +1,7 @@
 package com.github.rawls238.scientist4j;
 
 import com.github.rawls238.scientist4j.exceptions.MismatchException;
+import com.github.rawls238.scientist4j.metrics.NoopMetricsProvider;
 import org.junit.Test;
 
 import java.util.Date;
@@ -44,7 +45,7 @@ public class ExperimentAsyncTest {
 
     @Test
     public void itThrowsAnExceptionWhenControlFails() {
-      Experiment experiment = new Experiment("test");
+      Experiment<Integer> experiment = new Experiment<>("test", new NoopMetricsProvider());
       boolean controlThrew = false;
       try {
         experiment.runAsync(this::exceptionThrowingFunction, this::exceptionThrowingFunction);
@@ -58,7 +59,7 @@ public class ExperimentAsyncTest {
 
   @Test
   public void itDoesntThrowAnExceptionWhenCandidateFails() {
-    Experiment<Integer> experiment = new Experiment("test");
+    Experiment<Integer> experiment = new Experiment<>("test", new NoopMetricsProvider());
     boolean candidateThrew = false;
     Integer val = 0;
     try {
@@ -72,7 +73,7 @@ public class ExperimentAsyncTest {
 
   @Test
   public void itThrowsOnMismatch() {
-    Experiment<Integer> experiment = new Experiment("test", true);
+    Experiment<Integer> experiment = new Experiment<>("test", true, new NoopMetricsProvider());
     boolean candidateThrew = false;
     try {
       experiment.runAsync(this::safeFunction, this::safeFunctionWithDifferentResult);
@@ -87,7 +88,7 @@ public class ExperimentAsyncTest {
 
   @Test
   public void itDoesNotThrowOnMatch() {
-    Experiment<Integer> exp = new Experiment("test", true);
+    Experiment<Integer> exp = new Experiment<>("test", true, new NoopMetricsProvider());
     boolean candidateThrew = false;
     Integer val = 0;
     try {
@@ -102,7 +103,7 @@ public class ExperimentAsyncTest {
 
   @Test
   public void itWorksWithAnExtendedClass() {
-    Experiment<Integer> exp = new TestPublishExperiment("test");
+    Experiment<Integer> exp = new TestPublishExperiment<>("test", new NoopMetricsProvider());
     try {
       exp.run(this::safeFunction, this::safeFunction);
     } catch (Exception e) {
@@ -112,7 +113,7 @@ public class ExperimentAsyncTest {
 
   @Test
   public void asyncRunsFaster() {
-    Experiment<Integer> exp = new Experiment("test", true);
+    Experiment<Integer> exp = new Experiment<>("test", true, new NoopMetricsProvider());
     boolean candidateThrew = false;
     Integer val = 0;
     Date date1 = new Date();
@@ -137,6 +138,7 @@ public class ExperimentAsyncTest {
     ThreadFactory threadFactory = runnable -> new Thread(runnable, threadName);
     Experiment<String> exp = new ExperimentBuilder<String>()
         .withName("test")
+        .withMetricsProvider(new NoopMetricsProvider())
         .withExecutorService(Executors.newFixedThreadPool(4, threadFactory))
         .build();
     Callable<String> getThreadName = () -> Thread.currentThread().getName();
@@ -148,8 +150,8 @@ public class ExperimentAsyncTest {
 
   @Test
   public void raiseOnMismatchRunsSlower() throws Exception {
-    Experiment<Integer> raisesOnMismatch = new Experiment("raise", true);
-    Experiment<Integer> doesNotRaiseOnMismatch = new Experiment("does not raise");
+    Experiment<Integer> raisesOnMismatch = new Experiment<>("raise", true, new NoopMetricsProvider());
+    Experiment<Integer> doesNotRaiseOnMismatch = new Experiment<>("does not raise", new NoopMetricsProvider());
     final long raisesExecutionTime = timeExperiment(raisesOnMismatch);
     final long doesNotRaiseExecutionTime = timeExperiment(doesNotRaiseOnMismatch);
 

--- a/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/ExperimentTest.java
+++ b/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/ExperimentTest.java
@@ -2,9 +2,10 @@ package com.github.rawls238.scientist4j;
 
 import com.github.rawls238.scientist4j.exceptions.MismatchException;
 import com.github.rawls238.scientist4j.metrics.DropwizardMetricsProvider;
+import com.github.rawls238.scientist4j.metrics.MicrometerMetricsProvider;
+import com.github.rawls238.scientist4j.metrics.NoopMetricsProvider;
 import io.dropwizard.metrics5.Counter;
 import io.dropwizard.metrics5.MetricName;
-import io.dropwizard.metrics5.MetricRegistry;
 import org.junit.Test;
 
 import java.util.Date;
@@ -38,26 +39,26 @@ public class ExperimentTest {
 
     @Test(expected = ExpectingAnException.class)
     public void itThrowsAnExceptionWhenControlFails() throws Exception {
-        new Experiment<Integer>("test")
+        new Experiment<Integer>("test", new NoopMetricsProvider())
                 .run(this::exceptionThrowingFunction, this::exceptionThrowingFunction);
     }
 
     @Test
     public void itDoesntThrowAnExceptionWhenCandidateFails() throws Exception {
-        Experiment<Integer> experiment = new Experiment<>("test");
+        Experiment<Integer> experiment = new Experiment<>("test", new NoopMetricsProvider());
         Integer val = experiment.run(this::safeFunction, this::exceptionThrowingFunction);
         assertThat(val).isEqualTo(3);
     }
 
     @Test(expected = MismatchException.class)
     public void itThrowsOnMismatch() throws Exception {
-        new Experiment<Integer>("test", true)
+        new Experiment<Integer>("test", true, new NoopMetricsProvider())
                 .run(this::safeFunction, this::safeFunctionWithDifferentResult);
     }
 
     @Test
     public void itDoesNotThrowOnMatch() throws Exception {
-        Integer val = new Experiment<Integer>("test", true)
+        Integer val = new Experiment<Integer>("test", true, new NoopMetricsProvider())
                 .run(this::safeFunction, this::safeFunction);
 
         assertThat(val).isEqualTo(3);
@@ -65,7 +66,7 @@ public class ExperimentTest {
 
     @Test
     public void itHandlesNullValues() throws Exception {
-        Integer val = new Experiment<Integer>("test", true)
+        Integer val = new Experiment<Integer>("test", true, new NoopMetricsProvider())
                 .run(() -> null, () -> null);
 
         assertThat(val).isNull();
@@ -73,7 +74,7 @@ public class ExperimentTest {
 
     @Test
     public void nonAsyncRunsLongTime() throws Exception {
-        Experiment<Integer> exp = new Experiment<>("test", true);
+        Experiment<Integer> exp = new Experiment<>("test", true, new NoopMetricsProvider());
         Date date1 = new Date();
         Integer val = exp.run(this::sleepFunction, this::sleepFunction);
         Date date2 = new Date();
@@ -85,12 +86,12 @@ public class ExperimentTest {
 
     @Test
     public void itWorksWithAnExtendedClass() throws Exception {
-        Experiment<Integer> exp = new TestPublishExperiment<>("test");
+        Experiment<Integer> exp = new TestPublishExperiment<>("test", new NoopMetricsProvider());
         exp.run(this::safeFunction, this::safeFunction);
     }
 
     @Test
-    public void candidateExceptionsAreCounted() throws Exception {
+    public void candidateExceptionsAreCounted_dropwizard() throws Exception {
         final DropwizardMetricsProvider provider = new DropwizardMetricsProvider();
         Experiment<Integer> exp = new Experiment<>("test", provider);
 
@@ -101,12 +102,24 @@ public class ExperimentTest {
     }
 
     @Test
+    public void candidateExceptionsAreCounted_micrometer() throws Exception {
+        final MicrometerMetricsProvider provider = new MicrometerMetricsProvider();
+        Experiment<Integer> exp = new Experiment<>("test", provider);
+
+        exp.run(() -> 1, this::exceptionThrowingFunction);
+
+        io.micrometer.core.instrument.Counter result = provider.getRegistry().get("scientist.test.candidate.exception").counter();
+        assertThat(result.count()).isEqualTo(1);
+    }
+
+    @Test
     public void shouldUseCustomComparator() throws Exception {
         @SuppressWarnings("unchecked") final BiFunction<Integer, Integer, Boolean> comparator = mock(BiFunction.class);
         when(comparator.apply(1, 2)).thenReturn(false);
         final Experiment<Integer> e = new ExperimentBuilder<Integer>()
                 .withName("test")
                 .withComparator(comparator)
+                .withMetricsProvider(new NoopMetricsProvider())
                 .build();
 
         e.run(() -> 1, () -> 2);

--- a/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/ExperimentTest.java
+++ b/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/ExperimentTest.java
@@ -1,6 +1,7 @@
 package com.github.rawls238.scientist4j;
 
 import com.github.rawls238.scientist4j.exceptions.MismatchException;
+import com.github.rawls238.scientist4j.metrics.DropwizardMetricsProvider;
 import io.dropwizard.metrics5.Counter;
 import io.dropwizard.metrics5.MetricName;
 import io.dropwizard.metrics5.MetricRegistry;
@@ -90,12 +91,12 @@ public class ExperimentTest {
 
     @Test
     public void candidateExceptionsAreCounted() throws Exception {
-        MetricRegistry metrics = new MetricRegistry();
-        Experiment<Integer> exp = new Experiment<>("test", metrics);
+        final DropwizardMetricsProvider provider = new DropwizardMetricsProvider();
+        Experiment<Integer> exp = new Experiment<>("test", provider);
 
         exp.run(() -> 1, this::exceptionThrowingFunction);
 
-        Counter result = metrics.getCounters().get(MetricName.build("scientist", "test", "candidate", "exception"));
+        Counter result = provider.getRegistry().getCounters().get(MetricName.build("scientist", "test", "candidate", "exception"));
         assertThat(result.getCount()).isEqualTo(1);
     }
 

--- a/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/TestPublishExperiment.java
+++ b/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/TestPublishExperiment.java
@@ -1,10 +1,12 @@
 package com.github.rawls238.scientist4j;
 
+import com.github.rawls238.scientist4j.metrics.MetricsProvider;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestPublishExperiment<Integer> extends Experiment<Integer> {
-  TestPublishExperiment(String name) {
-    super(name);
+  TestPublishExperiment(String name, MetricsProvider<?> metricsProvider) {
+    super(name, metricsProvider);
   }
 
   @Override

--- a/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/metrics/NoopMetricsProvider.java
+++ b/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/metrics/NoopMetricsProvider.java
@@ -1,7 +1,9 @@
 package com.github.rawls238.scientist4j.metrics;
 
+import com.github.rawls238.scientist4j.metrics.MetricsProvider;
+
 /**
- * A default {@link MetricsProvider}, with a minimal in-memory implementation, suitable for test environments.
+ * A  minimal in-memory {@link MetricsProvider} implementation, suitable for test environments.
  */
 public class NoopMetricsProvider implements MetricsProvider<Object> {
 


### PR DESCRIPTION
Plus built-in concrete implementations: `DropwizardMetricsProvider`, `MicrometerMetricsProvider`. Both Dropwizard metrics and Micrometer are optional dependencies. If we prefer, these could be moved to separate modules.

With this change, I’m not sure if `getMetrics` is needed as an extension point—users will almost certainly be using a non-default `MetricsProvider`.

fixes #36 