### PR TITLE
Fix violations of Sonar rule 2142

### DIFF
--- a/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/ExperimentAsyncCandidateOnlyTest.java
+++ b/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/ExperimentAsyncCandidateOnlyTest.java
@@ -22,6 +22,7 @@ public class ExperimentAsyncCandidateOnlyTest {
       Thread.sleep(1001);
     } catch (InterruptedException e) {
       e.printStackTrace();
+      Thread.currentThread().interrupt();
     }
     return 3;
   }
@@ -31,6 +32,7 @@ public class ExperimentAsyncCandidateOnlyTest {
       Thread.sleep(101);
     } catch (InterruptedException e) {
       e.printStackTrace();
+      Thread.currentThread().interrupt();
     }
     return 3;
   }

--- a/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/IncompatibleTypesExperimentAsyncTest.java
+++ b/Scientist4JCore/src/test/java/com/github/rawls238/scientist4j/IncompatibleTypesExperimentAsyncTest.java
@@ -23,6 +23,7 @@ public class IncompatibleTypesExperimentAsyncTest {
             Thread.sleep(1001);
         } catch (InterruptedException e) {
             e.printStackTrace();
+            Thread.currentThread().interrupt();
         }
         return 3;
     }
@@ -32,6 +33,7 @@ public class IncompatibleTypesExperimentAsyncTest {
             Thread.sleep(1001);
         } catch (InterruptedException e) {
             e.printStackTrace();
+            Thread.currentThread().interrupt();
         }
         return "3";
     }


### PR DESCRIPTION
Hi,

This PR fixes 4 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.